### PR TITLE
Table 컴포넌트 overflow-auto div 제거

### DIFF
--- a/.changeset/rude-avocados-enjoy.md
+++ b/.changeset/rude-avocados-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@freemed-kit/ui': patch
+---
+
+Table 컴포넌트 overflow-auto div 제거

--- a/packages/ui/components/table.tsx
+++ b/packages/ui/components/table.tsx
@@ -4,9 +4,7 @@ import { cn } from '@/lib/utils'
 
 const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
   ({ className, ...props }, ref) => (
-    <div className="relative w-full overflow-auto">
-      <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
-    </div>
+    <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
   )
 )
 Table.displayName = 'Table'


### PR DESCRIPTION
## #️⃣ 관련 이슈

- #83 

## 💡 작업 내용
Table 고정 헤더 및 scrollable body 구현을 위해 div 요소를 제거했습니다.

## 📢 PR Point
